### PR TITLE
ci: add workflow for deploying on pull request

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -16,11 +16,12 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: true
 
       - name: Build
-        run: |
-         pnpm i
-         pnpm run build
+        run: pnpm run build
 
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on: [pull_request]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write 
+    name: Deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Build
+        run: |
+         pnpm i
+         pnpm run build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          directory: public
+        id: publish
+
+      - name: Comment deployment URL
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: Deployed at ${{ steps.publish.outputs.alias }}.


### PR DESCRIPTION
Cloudflare Pages does not deploy pull requests that originate from outside the repository. This workflow is manually implementing that with Direct Upload.