### PR TITLE
feat: Add starting routes layout for clubs and admin

### DIFF
--- a/app/routes/admin._index/route.tsx
+++ b/app/routes/admin._index/route.tsx
@@ -1,0 +1,6 @@
+export default function AdminIndex() {
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Admin Dashboard</h3>
+  </>
+}

--- a/app/routes/admin.clubs.$clubId._index/route.tsx
+++ b/app/routes/admin.clubs.$clubId._index/route.tsx
@@ -1,0 +1,11 @@
+import {useParams} from "@remix-run/react";
+
+export default function AdminClubsIndex() {
+  const params = useParams();
+  const clubId = params.clubId;
+
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Viewing admin page for club {clubId}</h3>
+  </>
+}

--- a/app/routes/admin.clubs.$clubId.requests.$requestId/route.tsx
+++ b/app/routes/admin.clubs.$clubId.requests.$requestId/route.tsx
@@ -1,0 +1,54 @@
+import { ActionArgs, json } from "@remix-run/cloudflare";
+
+import { Form, useActionData, useParams } from "@remix-run/react";
+
+export async function action({ request, params }: ActionArgs) {
+  const body = await request.formData();
+  const intent = body.get("intent");
+  //const { intent } = await request.json<RequestDecisionBody>();
+
+  if (
+    typeof intent !== "string" ||
+    !(intent === "deny" || intent === "approve")
+  ) {
+    return json(
+      { error: "No or bad `intent` specified", intent: null, id: null },
+      422
+    );
+  }
+
+  // TODO: modify things in the database
+  const requestId = params.requestId;
+  return json({ error: null, intent: intent, id: requestId });
+}
+
+export default function AdminClubRequestById() {
+  const params = useParams();
+  const clubId = params.clubId;
+  const requestId = params.requestId;
+
+  const actionData = useActionData<typeof action>();
+
+  return (
+    <>
+      <h1>Placeholder</h1>
+      <h3>
+        Admin Page for Club Request {requestId} belonging to club {clubId}
+      </h3>
+      {actionData ? (
+        <p>
+          Error: {actionData.error}; Intent received: {actionData.intent};
+          Request ID received: {actionData.id}
+        </p>
+      ) : null}
+      <Form method="post">
+        <button name="intent" value="approve">
+          Approve
+        </button>
+        <button name="intent" value="deny">
+          Deny
+        </button>
+      </Form>
+    </>
+  );
+}

--- a/app/routes/admin.clubs.$clubId.requests._index/route.tsx
+++ b/app/routes/admin.clubs.$clubId.requests._index/route.tsx
@@ -1,0 +1,11 @@
+import {useParams} from "@remix-run/react";
+
+export default function AdminClubsRequests() {
+  const params = useParams();
+  const clubId = params.clubId
+
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Admin Clubs Requests Dashboard for club {clubId}</h3>
+  </>
+}

--- a/app/routes/admin.clubs._index/route.tsx
+++ b/app/routes/admin.clubs._index/route.tsx
@@ -1,0 +1,6 @@
+export default function AdminClubsIndex() {
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Admin Clubs Dashboard</h3>
+  </>
+}

--- a/app/routes/admin.clubs.add/route.tsx
+++ b/app/routes/admin.clubs.add/route.tsx
@@ -1,0 +1,6 @@
+export default function AdminAddClub() {
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Admin page for adding a club</h3>
+  </>
+}

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,0 +1,7 @@
+import { Outlet } from "@remix-run/react";
+
+export default function Admin() {
+  return <>
+    <Outlet />
+  </>
+}

--- a/app/routes/clubs.$clubId._index/route.tsx
+++ b/app/routes/clubs.$clubId._index/route.tsx
@@ -1,0 +1,11 @@
+import { useParams } from "@remix-run/react";
+
+export default function Club() {
+  const params = useParams();
+  const clubId = params.clubId;
+
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Information about club {clubId}</h3>
+  </>
+}

--- a/app/routes/clubs.$clubId.edit/route.tsx
+++ b/app/routes/clubs.$clubId.edit/route.tsx
@@ -1,0 +1,11 @@
+import {useParams} from "@remix-run/react";
+
+export default function EditClub(){
+  const params = useParams();
+  const clubId = params.clubId;
+
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Edit club page for club {clubId}</h3>
+  </>
+}

--- a/app/routes/clubs.$clubId.members.$memberId.ts
+++ b/app/routes/clubs.$clubId.members.$memberId.ts
@@ -1,0 +1,6 @@
+import type { ActionArgs } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+
+export function action({ params }: ActionArgs) {
+  return json({ placeholder: `left club ${params.clubId}` });
+}

--- a/app/routes/clubs.$clubId.members.ts
+++ b/app/routes/clubs.$clubId.members.ts
@@ -1,0 +1,6 @@
+import type { ActionArgs } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+
+export function action({ params }: ActionArgs) {
+  return json({ placeholder: `joined club ${params.clubId}` });
+}

--- a/app/routes/clubs._index/route.tsx
+++ b/app/routes/clubs._index/route.tsx
@@ -1,0 +1,11 @@
+import { useParams } from "@remix-run/react";
+
+export default function Club() {
+  const params = useParams();
+  const id = params.id;
+
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Information about club {id}</h3>
+  </>
+}

--- a/app/routes/clubs.new/route.tsx
+++ b/app/routes/clubs.new/route.tsx
@@ -1,0 +1,6 @@
+export default function NewClub() {
+  return <>
+    <h1>Placeholder</h1>
+    <h3>Creating new club</h3>
+  </>
+}

--- a/app/routes/clubs.tsx
+++ b/app/routes/clubs.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from "@remix-run/react";
+
+export default function Clubs() {
+  return (
+    <>
+      <Outlet />
+    </>
+  );
+}


### PR DESCRIPTION
This commit introduces the starting layout proposed in #2. There is no functionality or "business logic" for any of the routes in this commit. These routes include unique pages for individual clubs as well as a collective overview on the admin side. Within these pages, there are functionalities for viewing and modifying specific aspects of each club, including the ability to approve or deny requests.